### PR TITLE
Change buttons to use pixelated image rendering

### DIFF
--- a/style.css
+++ b/style.css
@@ -372,6 +372,7 @@ body, #music_screen {
 
 .layer_button {
     padding: 0.6vw;
+    image-rendering: pixelated;
 }
 
 .button_icon {
@@ -392,6 +393,7 @@ body, #music_screen {
 .other_buttons {
     padding: 0.6vw;
     position: relative;
+    image-rendering: pixelated;
 }
 
 #region_name {


### PR DESCRIPTION
Currently, the layer buttons use the default image rendering logic, which uses bilinear interpolation for the images. This causes the pixel art to become blurred:
![firefox_4A7dwhOO0i](https://github.com/user-attachments/assets/12a18b3d-5de3-444d-9219-dfba38a262b4)

This pull request changes the buttons to use pixelated rendering instead to keep the sharp pixel art:
![image](https://github.com/user-attachments/assets/fedfe041-19c9-41ea-8956-eef3d3a0c1be)
